### PR TITLE
Proposal: Make the shutdownHook explicit to the Logging's caller

### DIFF
--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/App.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/App.kt
@@ -48,6 +48,7 @@ fun main() {
     wordChecker.logger = logging
 
     logging.log("Bot started")
+    logging.logOnShutdown("Bot stopped")
 
     configureCommands(api, dingDong, wordChainGame)
 }

--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/Logging.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/Logging.kt
@@ -6,15 +6,6 @@ import net.dv8tion.jda.api.JDA
 
 class Logging(private val guild: JDA?, private val guildId: Long, private val channelId: Long) {
     private val logger = KotlinLogging.logger {}
-    init {
-        if (guild != null) {
-            Runtime.getRuntime().addShutdownHook(object : Thread() {
-                override fun run() {
-                    log("Bot stopped")
-                }
-            })
-        }
-    }
 
     fun log(message: String) {
         logger.info { message }
@@ -24,6 +15,12 @@ class Logging(private val guild: JDA?, private val guildId: Long, private val ch
     private fun sendMessageToDiscordChannelById(guild: JDA, guildId: Long, channelId: Long, message: String) {
         val channel = guild.getGuildById(guildId)?.getTextChannelById(channelId)
         channel?.sendMessage(message)?.queue()
+    }
+
+    fun logOnShutdown(message: String) {
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+            override fun run() = log(message)
+        })
     }
 
     companion object {


### PR DESCRIPTION
This way has some advantages:
* The "Bot started" and "Bot stopped" messages are defined on the same level instead of hiding the stopped message inside the Logging class.
* We do not check 'if (guild != null)' anymore since we can call the 'logOnShutdown()' function when we know that we got the right instance.