### PR TITLE
Add a GitHub Action step for tracking code coverage

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -18,4 +18,14 @@ jobs:
     - name: Set up Docker Compose
       uses: docker/setup-compose-action@v1
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build jacocoLogTestCoverage
+    - name: Add coverage to PR
+      id: jacoco
+      uses: madrapps/jacoco-report@v1.7.2
+      with:
+        paths: ${{ github.workspace }}/**/build/reports/jacoco/**/jacocoTestReport.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 40
+        min-coverage-changed-files: 60
+        title: Code Coverage
+        update-comment: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
     alias(libs.plugins.flyway)
-
+    id("org.barfuin.gradle.jacocolog") version "3.1.0"
     application
 }
 


### PR DESCRIPTION
This adds a step to the GitHub build action that uses JaCoCo to generate a
code coverage report.

See https://github.com/marketplace/actions/jacoco-report for details.

(!) This pull request is based on the code introduced with PRs #18 and #19. Merge both first, please.