### PR TITLE
Set flyway schemas in Spring Boot's application config

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -6,7 +6,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    # show-sql: true
+  # for tests and development: let flyway search for the flyway_schema_history table in the right schema
+  flyway:
+    schemas: wordchaingame
 
 zonky:
   test:


### PR DESCRIPTION
For tests and development, the flyway migration is run by Spring Boot instead of Gradle. To search for the flyway_schema_history table in the right schema, we have to configure it in the application.yml as well.