### PR TITLE
Allow the build job to add comments to pull requests

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -5,6 +5,9 @@ on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4


### PR DESCRIPTION
The jacoco-report action wants to add a comment regarding code coverage to the pull request (if the build belongs to a PR). For that it needs the write permission.

See comments on issue https://github.com/Madrapps/jacoco-report/issues/24