### PR TITLE
Register 'integTest' as a JvmTestSuite instead of using a simple source set

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -32,7 +32,7 @@ jobs:
         GUILD_ID: ${{ vars.GUILD_ID }}
         LOGGING_CHANNEL_ID: ${{ vars.LOGGING_CHANNEL_ID }}
         WORDCHAINGAME_CHANNEL_ID: ${{ vars.WORDCHAINGAME_CHANNEL_ID }}
-      run: ./gradlew app:integrationTest
+      run: ./gradlew app:integTest
     - name: Test Report
       uses: dorny/test-reporter@v2
       if: ${{ !cancelled() }}  # run this step even if a previous step failed

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ In order for the Discord-related integration tests to run, see configuration fil
 in the integration test source set (`integTest`) and set the environment variables that are needed there. Use e.g., a
 run configuration in your IDE for that.
 
-You can run the integration tests with the Gradle task `integrationTest`:
+You can run the integration tests with the Gradle task `integTest`:
 
 ```shell
-./gradlew app:integrationTest
+./gradlew app:integTest
 ```
 
 ## On the server

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,19 +22,20 @@ repositories {
     mavenCentral()
 }
 
-sourceSets {
-    create("integTest") {
-        compileClasspath += sourceSets.main.get().output
-        runtimeClasspath += sourceSets.main.get().output
+testing {
+    suites {
+        register<JvmTestSuite>("integTest") {
+            dependencies { implementation(sourceSets.main.get().output) }
+        }
     }
 }
 
 val integTestImplementation: Configuration by configurations.getting {
-    extendsFrom(configurations.implementation.get())
+    extendsFrom(configurations.testImplementation.get())
 }
-val integTestRuntimeOnly by configurations.getting
-
-configurations["integTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
+val integTestRuntimeOnly: Configuration by configurations.getting {
+    extendsFrom(configurations.testRuntimeOnly.get())
+}
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -100,19 +101,7 @@ tasks {
         dependsOn(check)
     }
 
-    register<Test>("integrationTest") {
-        description = "Runs integration tests."
-        group = "verification"
-
-        testClassesDirs = sourceSets["integTest"].output.classesDirs
-        classpath = sourceSets["integTest"].runtimeClasspath
-        shouldRunAfter("test")
+    named<Test>("integTest") {
         finalizedBy(jacocoAggregatedReport)
-
-        useJUnitPlatform()
-
-        testLogging {
-            events("passed")
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration.cache=true


### PR DESCRIPTION
This has some advantages:
* less noisy and less redundant configuration in the build.gradle.kts
* the integTest source set is recognized as an actual test source set by the IDE and presented in that fashion (e.g. with green background in the project tree of IntelliJ IDEA)

Additionally: Activate Gradle's configuration cache for better build execution times during development.