### PR TITLE
#38 Make the channel ID for DingDongListener configurable

### DIFF
--- a/app/src/integTest/resources/application.yml
+++ b/app/src/integTest/resources/application.yml
@@ -9,5 +9,5 @@ word-chain-game:
   language: en
   check-word-existence: true
 
-ding-dong:
-  channel-id: ${DINGDONG_CHANNEL_ID}
+bottalking:
+  channel-id: ${BOTTALKING_CHANNEL_ID}

--- a/app/src/integTest/resources/application.yml
+++ b/app/src/integTest/resources/application.yml
@@ -8,3 +8,6 @@ word-chain-game:
   channel-id: ${WORDCHAINGAME_CHANNEL_ID}
   language: en
   check-word-existence: true
+
+ding-dong:
+  channel-id: ${DINGDONG_CHANNEL_ID}

--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/App.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/App.kt
@@ -1,6 +1,7 @@
 package de.dagadeta.schlauerbot
 
 import de.dagadeta.schlauerbot.config.BotAuthConfig
+import de.dagadeta.schlauerbot.config.DingDongConfig
 import de.dagadeta.schlauerbot.config.LoggingConfig
 import de.dagadeta.schlauerbot.config.WordChainGameConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -11,9 +12,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 @SpringBootApplication
 @EnableTransactionManagement
 @EnableConfigurationProperties(
+    BotAuthConfig::class,
+    DingDongConfig::class,
     LoggingConfig::class,
     WordChainGameConfig::class,
-    BotAuthConfig::class,
 )
 class DiscordBotApplication
 

--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/config/DiscordBotConfig.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/config/DiscordBotConfig.kt
@@ -18,7 +18,7 @@ data class WordChainGameConfig(
     val checkWordExistence: Boolean,
 )
 
-@ConfigurationProperties(prefix = "ding-dong")
+@ConfigurationProperties(prefix = "bottalking")
 data class DingDongConfig(
     val channelId: String,
 )

--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/config/DiscordBotConfig.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/config/DiscordBotConfig.kt
@@ -17,3 +17,8 @@ data class WordChainGameConfig(
     val language: String,
     val checkWordExistence: Boolean,
 )
+
+@ConfigurationProperties(prefix = "ding-dong")
+data class DingDongConfig(
+    val channelId: String,
+)

--- a/app/src/main/kotlin/de/dagadeta/schlauerbot/dingdong/DingDongListener.kt
+++ b/app/src/main/kotlin/de/dagadeta/schlauerbot/dingdong/DingDongListener.kt
@@ -1,5 +1,6 @@
 package de.dagadeta.schlauerbot.dingdong
 
+import de.dagadeta.schlauerbot.config.DingDongConfig
 import de.dagadeta.schlauerbot.discord.Logging
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
@@ -16,6 +17,7 @@ const val dingCommand = "ding"
 
 @Service
 class DingDongListener(
+    private val dingDongConfig: DingDongConfig,
     private val logging: Logging,
     private val api: JDA,
 ) : ListenerAdapter() {
@@ -35,7 +37,7 @@ class DingDongListener(
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
-        if (event.channel.name != "\uD83E\uDD16｜bot-spielplatz") return
+        if (event.channel.id != dingDongConfig.channelId) return
         if (event.name != dingCommand) return
 
         logger.info { "received !ding" }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -38,5 +38,5 @@ word-chain-game:
   language: 0
   check-word-existence: true
 
-ding-dong:
+bottalking:
   channel-id: 0

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -37,3 +37,6 @@ word-chain-game:
   channel-id: 0
   language: 0
   check-word-existence: true
+
+ding-dong:
+  channel-id: 0

--- a/config/application-prod.yml.template
+++ b/config/application-prod.yml.template
@@ -18,3 +18,6 @@ word-chain-game:
   channel-id: ENTER_YOUR_WORD_CHAIN_GAME_CHANNEL_ID
   language: ENTER_YOUR_DICTIONARY_LANGUAGE
   check-word-existence: ENTER_TRUE_OR_FALSE
+
+ding-dong:
+  channel-id: ENTER_YOUR_DING_DONG_CHANNEL_ID

--- a/config/application-prod.yml.template
+++ b/config/application-prod.yml.template
@@ -19,5 +19,6 @@ word-chain-game:
   language: ENTER_YOUR_DICTIONARY_LANGUAGE
   check-word-existence: ENTER_TRUE_OR_FALSE
 
-ding-dong:
-  channel-id: ENTER_YOUR_DING_DONG_CHANNEL_ID
+# The channel-id is the ID of the Discord channel where general slash-commands will be executable.
+bottalking:
+  channel-id: ENTER_YOUR_BOTTALKING_CHANNEL_ID


### PR DESCRIPTION
Note that for the integTests to run successfully, the new
DINGDONG_CHANNEL_ID has to be configured as a GitHub
secret or environment variable.